### PR TITLE
add rcon-cli

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,14 +1,1 @@
 # discord-game-login-notifier と requirements.txt のみ含める
-/.devcontainer
-/.git
-/.github
-/.gitignore
-/Dockerfile
-/LICENSE
-/README.md
-/compose.yaml
-/doc
-/example.env
-/poetry.lock
-/pyproject.toml
-/venv

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM python:3.12.1 
 
-COPY .. ./DiscordGameLoginNotifier
-WORKDIR /DiscordGameLoginNotifier
+WORKDIR /app
+COPY discord-game-login-notifier/ .
+COPY requirements.txt .
+COPY rcon-cli /usr/local/bin/
 RUN pip install -r requirements.txt
 
-ENTRYPOINT [ "python3", "-u", "./discord-game-login-notifier/main.py" ]
+ENTRYPOINT [ "python3", "-u", "main.py" ]

--- a/rcon-cli
+++ b/rcon-cli
@@ -1,0 +1,3 @@
+#!/bin/sh
+echo "$@" | mcrcon --password ${DGLN_RCON_PASSWORD} -p ${DGLN_RCON_PORT} ${DGLN_RCON_ADDRESS}
+


### PR DESCRIPTION
* dockerを動かしているホストからも rcon が使える様に以下のコマンドを実現します。
`docker exec -it <コンテナ名> rcon-cli <コマンド>`
* .dockerignore で除外指定するものが多すぎるため、
必要なファイルのみ Dockerfile に記述する事でシンプルにしました。
